### PR TITLE
make plotly charts have hoverlabel name length -1

### DIFF
--- a/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/box-single-axis.json
+++ b/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/box-single-axis.json
@@ -35,6 +35,9 @@
         "type": "linear",
         "autorange": true,
         "range": null
+      },
+      "hoverlabel": {
+        "namelength": -1
       }
     }
   }

--- a/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/box-with-second-axis.json
+++ b/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/box-with-second-axis.json
@@ -47,6 +47,9 @@
         "range": null,
         "overlaying": "y",
         "side": "right"
+      },
+      "hoverlabel": {
+        "namelength": -1
       }
     }
   }

--- a/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/default-single-axis.json
+++ b/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/default-single-axis.json
@@ -33,6 +33,9 @@
         "type": "linear",
         "autorange": true,
         "range": null
+      },
+      "hoverlabel": {
+        "namelength": -1
       }
     }
   }

--- a/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/default-with-second-axis.json
+++ b/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/default-with-second-axis.json
@@ -45,6 +45,9 @@
         "range": null,
         "overlaying": "y",
         "side": "right"
+      },
+      "hoverlabel": {
+        "namelength": -1
       }
     }
   }

--- a/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/default-with-stacking.json
+++ b/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/default-with-stacking.json
@@ -32,6 +32,9 @@
         "type": "linear",
         "autorange": true,
         "range": null
+      },
+      "hoverlabel": {
+        "namelength": -1
       }
     }
   }

--- a/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/default-without-legend.json
+++ b/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/default-without-legend.json
@@ -31,6 +31,9 @@
         "type": "linear",
         "autorange": true,
         "range": null
+      },
+      "hoverlabel": {
+        "namelength": -1
       }
     }
   }

--- a/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/pie-multiple-series.json
+++ b/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/pie-multiple-series.json
@@ -19,6 +19,9 @@
       "legend": {
         "traceorder": "normal"
       },
+      "hoverlabel": {
+        "namelength": -1
+      },    
       "annotations": [
         {
           "x": 0.24,

--- a/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/pie-without-annotations.json
+++ b/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/pie-without-annotations.json
@@ -19,6 +19,9 @@
       "legend": {
         "traceorder": "normal"
       },
+      "hoverlabel": {
+        "namelength": -1
+      },    
       "annotations": []
     }
   }

--- a/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/pie.json
+++ b/viz-lib/src/visualizations/chart/plotly/fixtures/prepareLayout/pie.json
@@ -19,6 +19,9 @@
       "legend": {
         "traceorder": "normal"
       },
+      "hoverlabel": {
+        "namelength": -1
+      },    
       "annotations": [
         {
           "x": 0.49,

--- a/viz-lib/src/visualizations/chart/plotly/prepareLayout.ts
+++ b/viz-lib/src/visualizations/chart/plotly/prepareLayout.ts
@@ -117,6 +117,9 @@ export default function prepareLayout(element: any, options: any, data: any) {
     legend: {
       traceorder: options.legend.traceorder,
     },
+    hoverlabel: {
+      namelength: -1,
+    },
   };
 
   switch (options.globalSeriesType) {


### PR DESCRIPTION
these dot dot dots are not helpful

![143988127-3590bd2f-e4da-43bc-9ca2-b3ef9e8f1407](https://user-images.githubusercontent.com/1988030/143988242-07f13e97-7182-4f6d-a753-02e6c5cdbe2f.png)

also made a pr to upstream https://github.com/getredash/redash/pull/5661

NOTE to scaleapi members: This is a fork of a public repo and therefore is public to internet!